### PR TITLE
Update cwb_lorebookManager

### DIFF
--- a/CharacterWorldBook/src/cwb_lorebookManager.js
+++ b/CharacterWorldBook/src/cwb_lorebookManager.js
@@ -12,7 +12,12 @@ export async function getTargetWorldBook() {
         return state.customWorldBook;
     }
     try {
-        const primaryBook = await TavernHelper.getCurrentCharPrimaryLorebook();
+        let localTavernHelper = TavernHelper;
+        if (!localTavernHelper) {
+            console.log("TavernHelper 未定义，尝试重建");
+        }
+        (localTavernHelper = window.TavernHelper);
+        const primaryBook = await localTavernHelper.getCurrentCharPrimaryLorebook();
         if (!primaryBook) {
             showToastr('error', '当前角色未设置主世界书。');
             return null;

--- a/CharacterWorldBook/src/cwb_lorebookManager.js
+++ b/CharacterWorldBook/src/cwb_lorebookManager.js
@@ -14,9 +14,9 @@ export async function getTargetWorldBook() {
     try {
         let localTavernHelper = TavernHelper;
         if (!localTavernHelper) {
-            console.log("TavernHelper 未定义，尝试重建");
+            // TavernHelper 未定义的情况下触发，但是为什么？
+            (localTavernHelper = window.TavernHelper);
         }
-        (localTavernHelper = window.TavernHelper);
         const primaryBook = await localTavernHelper.getCurrentCharPrimaryLorebook();
         if (!primaryBook) {
             showToastr('error', '当前角色未设置主世界书。');


### PR DESCRIPTION
调整添加重获取TavernHelper对象的处理，一定程度上可以避免出现获取世界书时TavernHelper未定义导致世界书名无法获取的情况（我必须得说这是个很不优雅的修正方案，但是能跑起来先）