### PR TITLE
Update cwb_lorebookManager

### DIFF
--- a/CharacterWorldBook/src/cwb_uiManager.js
+++ b/CharacterWorldBook/src/cwb_uiManager.js
@@ -145,7 +145,7 @@ function createCharCardViewerPopupHtml(displayItems) {
                 if (charData.psyche_profile) html += renderCard('心智侧写', charData.psyche_profile, 'psyche_profile');
                 if (charData.social_matrix) html += renderCard('社交矩阵', charData.social_matrix, 'social_matrix');
                 if (charData.narrative_essence) html += renderCard('叙事精粹', charData.narrative_essence, 'narrative_essence');
-                
+
                 html += `<div class="cwb-cyber-card cwb-insertion-settings-card">
                             <h4 class="cwb-cyber-card__title">注入设置</h4>
                             <div class="cwb-cyber-card__content cwb-insertion-settings-content">
@@ -184,7 +184,7 @@ function createCharCardViewerPopupHtml(displayItems) {
 }
 
 function bindCharCardViewerPopupEvents($popup) {
-    $popup.on('change', '.cwb-insertion-position', function() {
+    $popup.on('change', '.cwb-insertion-position', function () {
         const $this = $(this);
         const $depthContainer = $this.closest('.cwb-insertion-settings-content').find('.cwb-insertion-depth-container');
         if ($this.val() === 'at_depth') {
@@ -200,7 +200,7 @@ function bindCharCardViewerPopupEvents($popup) {
         showCharCardViewerPopup();
     });
 
-    $popup.find('#cwb-manual-update-btn').on('click', async function() {
+    $popup.find('#cwb-manual-update-btn').on('click', async function () {
         const $button = $(this);
         $button.prop('disabled', true).html('<i class="fas fa-spinner fa-spin"></i> 更新中...');
         await manualUpdateLogic();
@@ -217,7 +217,7 @@ function bindCharCardViewerPopupEvents($popup) {
         $popup.find(`#cwb-char-content-${targetUid}`).addClass('active');
     });
 
-    $popup.find('.cwb-cyber-tab__delete').on('click', async function(e) {
+    $popup.find('.cwb-cyber-tab__delete').on('click', async function (e) {
         e.stopPropagation();
         if (confirm('您确定要删除这个角色条目吗？此操作不可撤销。')) {
             const uidToDelete = $(this).data('char-uid');
@@ -235,9 +235,9 @@ function bindCharCardViewerPopupEvents($popup) {
         }
     });
 
-    $popup.find('#cwb-viewer-delete-all').on('click', async function() {
+    $popup.find('#cwb-viewer-delete-all').on('click', async function () {
         if (confirm('您确定要清除当前聊天中的所有角色卡和总览吗？此操作将删除所有相关条目，且不可撤销。')) {
-            const allUids = $popup.find('.cwb-cyber-tab__button').map(function() {
+            const allUids = $popup.find('.cwb-cyber-tab__button').map(function () {
                 return $(this).data('char-uid');
             }).get();
             if (allUids.length > 0) {
@@ -278,10 +278,15 @@ function bindCharCardViewerPopupEvents($popup) {
                 if ($field.data('is-array')) {
                     value = value.split('\n').map(l => l.trim()).filter(Boolean);
                 }
-                if(path){
-                   setNestedValue(collectedData, path, value);
+                if (path) {
+                    setNestedValue(collectedData, path, value);
                 }
             });
+            let localTavernHelper = TavernHelper;
+            if (!localTavernHelper) {
+                // TavernHelper 未定义的情况下触发，但是为什么？
+                (localTavernHelper = window.TavernHelper);
+            }
             const finalContentToSave = buildCustomFormat(collectedData);
             const allEntries = await TavernHelper.getLorebookEntries(book);
             const entryToUpdate = allEntries.find(e => e.uid === targetUid);
@@ -299,7 +304,7 @@ function bindCharCardViewerPopupEvents($popup) {
 
             const positionMap = {
                 'before_char': 'before_character_definition',
-                'after_char': 'after_character_definition', 
+                'after_char': 'after_character_definition',
                 'before_an': 'before_author_note',
                 'after_an': 'after_author_note',
                 'at_depth': 'at_depth_as_system'
@@ -309,7 +314,7 @@ function bindCharCardViewerPopupEvents($popup) {
 
             finalEntryData.content = finalContentToSave;
             finalEntryData.uid = targetUid;
-            
+
             const newPosition = positionMap[insertionPosition];
             finalEntryData.position = newPosition || 'before_character_definition';
             if (insertionPosition === 'at_depth') {
@@ -317,7 +322,7 @@ function bindCharCardViewerPopupEvents($popup) {
             } else {
                 finalEntryData.depth = null;
             }
-            
+
             finalEntryData.order = isNaN(insertionOrder) ? 7001 : insertionOrder;
 
             logDebug(`[DEBUG] 最终保存数据 UID:${targetUid}`, {
@@ -326,7 +331,11 @@ function bindCharCardViewerPopupEvents($popup) {
                 order: finalEntryData.order,
                 hasDepthField: 'depth' in finalEntryData
             });
-
+            localTavernHelper = TavernHelper;
+            if (!localTavernHelper) {
+                // TavernHelper 未定义的情况下触发，但是为什么？
+                (localTavernHelper = window.TavernHelper);
+            }
             await TavernHelper.setLorebookEntries(book, [finalEntryData]);
             showToastr('success', '角色卡已成功保存！');
         } catch (error) {
@@ -343,7 +352,7 @@ function closeCharCardViewerPopup() {
 }
 
 export async function showCharCardViewerPopup() {
-    if (!isCwbEnabled()) return; 
+    if (!isCwbEnabled()) return;
     closeCharCardViewerPopup();
     try {
         const book = await getTargetWorldBook();
@@ -352,6 +361,11 @@ export async function showCharCardViewerPopup() {
             $('body').append(createCharCardViewerPopupHtml([]));
             bindCharCardViewerPopupEvents($(`#${CHAR_CARD_VIEWER_POPUP_ID}`));
             return;
+        }
+        let localTavernHelper = TavernHelper;
+        if (!localTavernHelper) {
+            // TavernHelper 未定义的情况下触发，但是为什么？
+            (localTavernHelper = window.TavernHelper);
         }
         const allEntries = await TavernHelper.getLorebookEntries(book);
         let currentChatId = state.currentChatFileIdentifier;
@@ -362,7 +376,7 @@ export async function showCharCardViewerPopup() {
             bindCharCardViewerPopupEvents($(`#${CHAR_CARD_VIEWER_POPUP_ID}`));
             return;
         }
-        
+
         const cleanChatId = currentChatId.replace(/ imported/g, '');
         let displayItems = [];
 
@@ -379,28 +393,28 @@ export async function showCharCardViewerPopup() {
                         return false;
                     }
                 }
-                
+
                 return false;
             });
         } else {
-            relevantEntries = allEntries.filter(entry => 
+            relevantEntries = allEntries.filter(entry =>
                 entry.enabled &&
                 Array.isArray(entry.keys) &&
                 entry.keys.includes(cleanChatId)
             );
         }
 
-        const rosterEntries = relevantEntries.filter(entry => 
+        const rosterEntries = relevantEntries.filter(entry =>
             entry.keys.includes('Amily2角色总集') && entry.keys.includes('角色总览')
         );
 
         rosterEntries.forEach((entry, index) => {
-            displayItems.push({ 
-                uid: entry.uid, 
-                isRoster: true, 
-                comment: entry.comment, 
+            displayItems.push({
+                uid: entry.uid,
+                isRoster: true,
+                comment: entry.comment,
                 content: entry.content,
-                rosterIndex: index 
+                rosterIndex: index
             });
         });
 
@@ -417,7 +431,7 @@ export async function showCharCardViewerPopup() {
                 const positionStringMap = {
                     0: 'before_char',
                     1: 'after_char',
-                    2: 'before_an', 
+                    2: 'before_an',
                     3: 'after_an',
                     4: 'at_depth',
                     'before_character_definition': 'before_char',
@@ -448,7 +462,7 @@ export async function showCharCardViewerPopup() {
                 };
             })
             .filter(c => c.parsed && Object.keys(c.parsed).length > 0);
-        
+
         displayItems = displayItems.concat(characterEntries);
 
         const popupHtml = createCharCardViewerPopupHtml(displayItems);
@@ -553,7 +567,7 @@ function makeButtonDraggable($button) {
 
 export function initializeCharCardViewer() {
     const $existingButton = $(`#${CHAR_CARD_VIEWER_BUTTON_ID}`);
-    
+
     if ($existingButton.length > 0) {
         console.log('[CWB] Char card viewer button already exists');
         setTimeout(() => {
@@ -563,12 +577,12 @@ export function initializeCharCardViewer() {
         }, 100);
         return;
     }
-    
+
     const buttonHtml = `<div id="${CHAR_CARD_VIEWER_BUTTON_ID}" title="查看角色世界书" class="fa-solid fa-book-open"></div>`;
     $('body').append(buttonHtml);
     const $viewerButton = $(`#${CHAR_CARD_VIEWER_BUTTON_ID}`);
     makeButtonDraggable($viewerButton);
-    
+
     const savedPosition = JSON.parse(localStorage.getItem(state.STORAGE_KEY_VIEWER_BUTTON_POS) || 'null');
     if (savedPosition) {
         $viewerButton.css({ top: savedPosition.top, left: savedPosition.left });
@@ -581,9 +595,9 @@ export function initializeCharCardViewer() {
         $viewerButton.toggle(shouldShow);
         console.log(`[CWB] New button created with visibility: ${shouldShow}`);
     }, 100);
-    
+
     console.log('[CWB] Char card viewer button initialized');
-    
+
     let resizeTimeout;
     $(window).on('resize.cwbViewer', function () {
         clearTimeout(resizeTimeout);
@@ -594,9 +608,9 @@ export function initializeCharCardViewer() {
 export function updateViewerButtonVisibility() {
     const $button = $(`#${CHAR_CARD_VIEWER_BUTTON_ID}`);
     const shouldShow = isCwbEnabled() && state.viewerEnabled;
-    
+
     console.log(`[CWB] Updating viewer button visibility: ${shouldShow} (master: ${isCwbEnabled()}, viewer: ${state.viewerEnabled})`);
-    
+
     if ($button.length > 0) {
         $button.toggle(shouldShow);
         console.log(`[CWB] Viewer button visibility set to: ${shouldShow}`);
@@ -607,7 +621,7 @@ export function updateViewerButtonVisibility() {
             initializeCharCardViewer();
         }, 500);
     }
-    
+
     logDebug('悬浮窗按钮显示状态更新:', {
         masterEnabled: isCwbEnabled(),
         viewerEnabled: state.viewerEnabled,
@@ -617,43 +631,43 @@ export function updateViewerButtonVisibility() {
 
 export function bindCwbApiEvents() {
     console.log('[CWB] Binding API events');
-    
-    $('#cwb-api-url').off('input').on('input', function() {
+
+    $('#cwb-api-url').off('input').on('input', function () {
         const value = $(this).val();
         extension_settings[extensionName].cwb_api_url = value;
         saveSettingsDebounced();
     });
 
-    $('#cwb-api-key').off('input').on('input', function() {
+    $('#cwb-api-key').off('input').on('input', function () {
         const value = $(this).val();
         extension_settings[extensionName].cwb_api_key = value;
         saveSettingsDebounced();
     });
 
-    $('#cwb-model').off('input').on('input', function() {
+    $('#cwb-model').off('input').on('input', function () {
         const value = $(this).val();
         extension_settings[extensionName].cwb_model = value;
         saveSettingsDebounced();
     });
 
-    $('#cwb-temperature').off('input').on('input', function() {
+    $('#cwb-temperature').off('input').on('input', function () {
         const value = parseFloat($(this).val());
         $('#cwb-temperature-value').text(value);
         extension_settings[extensionName].cwb_temperature = value;
         saveSettingsDebounced();
     });
 
-    $('#cwb-max-tokens').off('input').on('input', function() {
+    $('#cwb-max-tokens').off('input').on('input', function () {
         const value = parseInt($(this).val());
         $('#cwb-max-tokens-value').text(value);
         extension_settings[extensionName].cwb_max_tokens = value;
         saveSettingsDebounced();
     });
 
-    $('#cwb-test-connection').off('click').on('click', async function() {
+    $('#cwb-test-connection').off('click').on('click', async function () {
         const $button = $(this);
         $button.prop('disabled', true).html('<i class="fas fa-spinner fa-spin"></i> 测试中...');
-        
+
         try {
             await testCwbConnection();
         } catch (error) {
@@ -663,15 +677,15 @@ export function bindCwbApiEvents() {
         }
     });
 
-    $('#cwb-fetch-models').off('click').on('click', async function() {
+    $('#cwb-fetch-models').off('click').on('click', async function () {
         const $button = $(this);
         $button.prop('disabled', true).html('<i class="fas fa-spinner fa-spin"></i> 获取中...');
-        
+
         try {
             const models = await fetchCwbModels();
             const $modelSelect = $('#cwb-model');
             $modelSelect.empty();
-            
+
             if (models && models.length > 0) {
                 models.forEach(model => {
                     $modelSelect.append(new Option(model.name, model.id));


### PR DESCRIPTION
一定程度上可以避免出现获取世界书时TavernHelper未定义导致世界书名无法获取的情况（我必须得说这依旧是个很不优雅的修正方案）
似乎TavernHelper在使用时有概率因为window对象重建导致旧对象引用失效，将TavernHelper改为随用随取更加和合适一些。